### PR TITLE
fixed math package triggered when single number is entered 

### DIFF
--- a/packages/math/index.js
+++ b/packages/math/index.js
@@ -23,6 +23,9 @@ async function math(query) {
 // window.math = math("2 + 2");
 
 async function trigger(query) {
+  if(!isNaN(query)) {
+    return false;
+  }
   try {
     mathjs.eval(query);
     return true;


### PR DESCRIPTION
![obraz](https://user-images.githubusercontent.com/32012330/71529208-e9000000-28e3-11ea-8685-a1b2a1223165.png)

Currently, when you enter a single number as a query, without the arguments, math package is triggered but there's no math operation. I've added if statement that will fix it
