### PR TITLE
Prevent dictionary package from beign triggered when it shouldn't be...

### DIFF
--- a/packages/dictionary/index.js
+++ b/packages/dictionary/index.js
@@ -18,6 +18,14 @@ async function dictionary(query) {
 				else definitions[item.type] = [item];
 			});
 
+			// Check if there's no definition
+			if(definitions.undefined) {
+				return `
+				<div class="mainCol dictMainCol">
+					<h3 class="dictWord"><span style="font-weight:normal">Sorry, no definition found for</span> ${word}</h3>
+				</div>`
+			}
+
 			return `
 				<div class="mainCol dictMainCol">
 					<h2 class="dictWord">${word}</h2>
@@ -83,6 +91,12 @@ async function dictionary(query) {
 }
 
 async function trigger(query) {
+	// split the query to trigger the package only when "define" is used
+	query = query.split(' ');
+
+	// return false when there's no other word 
+	if (query.length === 1) return false;
+	
 	return query.includes('define') ? true : false;
 }
 

--- a/packages/dictionary/index.js
+++ b/packages/dictionary/index.js
@@ -94,9 +94,9 @@ async function trigger(query) {
 	// split the query to trigger the package only when "define" is used
 	query = query.split(' ');
 
-	// return false when there's no other word 
-	if (query.length === 1) return false;
-	
+	// return false when there's no other word than define in query
+	if (query.length === 1 || query.includes('')) return false;
+
 	return query.includes('define') ? true : false;
 }
 

--- a/packages/dictionary/package.json
+++ b/packages/dictionary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dictionary",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Dictionary Instant Answer",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
For example, when the query is `function is undefined`, it will trigger the package because query includes define in `unDEFINEd`
#### 
![obraz](https://user-images.githubusercontent.com/32012330/73357185-274e5d80-429c-11ea-8547-e520c86969c1.png)
_____________
#####
When there's no results from the dictionary API, it displays a definition results without the definition. I've switched it to the simple error response.
#####
![obraz](https://user-images.githubusercontent.com/32012330/73357319-73010700-429c-11ea-9a33-162d09b344ad.png)

