### PR TITLE
Stocks was excluded from the trigger function but if there was a token/coin

### DIFF
--- a/packages/cryptoInfo/index.js
+++ b/packages/cryptoInfo/index.js
@@ -10,9 +10,10 @@ async function cryptoInfo(query) {
     let coin_id;
     for (let coin of coin_list) {
       if (
-        coin.id === query ||
-        coin.name.toLowerCase() === query ||
-        coin.symbol === query
+        (coin.id === query ||
+          coin.name.toLowerCase() === query ||
+          coin.symbol === query) &&
+        !coin.symbol.toLowerCase().includes(".cx")
       ) {
         coin_id = coin.id;
         break;


### PR DESCRIPTION
with the same name as a stock, the package was triggered, but the stock price was displayed instead of coin/token price. Fix - extra if check to the main function to ensure that stock prices are not displayed.