### PR TITLE
Currency converter - Bugfix, searching for sentences including crypto gives results

### DIFF
--- a/packages/currencyConverter/package.json
+++ b/packages/currencyConverter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "currencyConverter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Convert currencies",
   "main": "index.js",
   "scripts": {

--- a/packages/currencyConverter/services.js
+++ b/packages/currencyConverter/services.js
@@ -59,7 +59,6 @@ function parseAndNormalize(query) {
     )
   })
 
-
   let valueString, from, to;
 
   if (filteredMatch && filteredMatch.length) {

--- a/packages/currencyConverter/services.js
+++ b/packages/currencyConverter/services.js
@@ -44,7 +44,7 @@ function parseAndNormalize(query) {
 
   // check for the input eg. "3 EUR to USD"
   // we are expecting fiat currencies to have 3 chars and crypto currencies to have up to 8 chars (at least most of them)
-  const match = query.match(/((\d+(\.\d+)?) )?([A-Z]{2,8}) {0,1}(TO|INTO|=| ) {0,1}([A-Z]{2,8})/);
+  const match = query.match(/^((\d+(\.\d+)?) )?([A-Z]{2,8}) {0,1}(TO|INTO|=| ) {0,1}([A-Z]{2,8})$/);
 
   if (!match) {
     return undefined;
@@ -55,9 +55,10 @@ function parseAndNormalize(query) {
     if(!el) return false;
     const lowercaseEl = el.toLowerCase();
     return (
-      el != query && !el.includes(" ") && lowercaseEl != query && lowercaseEl != "to" && lowercaseEl != "into" && lowercaseEl != "=" && lowercaseEl != " "
+      el != query && !el.includes(" ") && lowercaseEl != query && lowercaseEl != "to" && lowercaseEl != "into" && lowercaseEl != "=" && lowercaseEl != " " && !lowercaseEl.startsWith(".")
     )
   })
+
 
   let valueString, from, to;
 
@@ -83,7 +84,7 @@ function parseAndNormalize(query) {
   }
 
   const fromName = (cryptoCurrencies[from] && !fiatCurrencies[from]) ? cryptoCurrencies[from].name : '';
-  
+
   return { value, from, to, fromName};
 }
 


### PR DESCRIPTION
I was searching for `flux chain explorer` and I got the currency conversion rate for Flux to Chain. This PR will limit currency conversion and disable it when writing sentences (or at least more words then `flux to chain`, `flux chain`, `5 flux to chain`, etc).